### PR TITLE
A few updates and typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,24 @@ bash solr-8.11.1/bin/install_solr_service.sh solr-8.11.1.tgz
 
 This will install SOLR. Please check the installation success by monitoring the output of 
 
-```systemctl start solr```
+```
+systemctl start solr
+```
 
 We'll leave SOLR alone for now and will return later to create the docspell core.
 
-## Postgresql Installation
+*Note: From version 0.34.0 it is also possible to use PostgreSQL as fulltext search engine. This is not described here, the main documention has [some instructions](https://docspell.org/docs/configure/fulltext-search/)*
+
+## Enable SOLR fulltext search
+
+We need to create a SOLR core and make it available in Docspell:
+
+```
+su solr -c '/opt/solr-8.11.1/bin/solr create -c docspell'
+```
+
+
+## PostgreSQL Installation
 
 PostgreSQL is my preferred database for docspell because of the amount of documents I am storing in it. Other database types are also available, please have a look at the docspell Repo for more information.
 
@@ -47,11 +60,13 @@ sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg mai
 apt update && apt full-upgrade
 apt install postgresql-14
 ```
+
 ### PostgreSQL Configuration
 
-In the following section, you need to replace YOURPASSWORD with your own. I am using ```docspell``` as the database owner and ```docspelldb``` as the database name:
+In the following section, you need to replace YOURPASSWORD with your own. I am using `docspell` as the database owner and `docspelldb` as the database name:
 
 Loginto the Postgres user
+
 ```
 $ sudo su -
 root@debian-11:~# su - postgres
@@ -65,18 +80,14 @@ Create the user docspell
 postgres=# CREATE USER docspell
 postgres-# WITH SUPERUSER CREATEDB CREATEROLE
 postgres-# PASSWORD 'YOURPASSWORD';
-exit
 ```
 
-Create the database and connect to it
+Create the database and (as a test) connect to it
 ```
-psql postgres
-CREATE DATABASE docspelldb WITH OWNER docspell;
-CREATE DATABASE
+postgres=# CREATE DATABASE docspelldb WITH OWNER docspell;
 postgres=# \connect docspelldb;
 You are now connected to database "docspelldb" as user "docspell".
-docspelldb=#
-\q
+docspelldb=# \q
 ```
 
 Dont forget to logout from the postgres user ("exit") until you are back to the root user and make sure the database is started with the system:
@@ -84,6 +95,7 @@ Dont forget to logout from the postgres user ("exit") until you are back to the 
 ```
 systemctl enable postgresql
 ```
+
 ### Set up a scheduled database backup
 
 Because the database also holds the PDFs, I strongly recommend to create an automated backup. Copy the file postgres-backup.sh to /opt and edit it to your needs. As this stores the backup in a local folder, make sure to have a way to automatically transfer them to your backup storage.
@@ -104,7 +116,9 @@ For the first time, i'd suggest to run the script manually to get an idea of the
 
 ## Docspell installation
 
-Make sure to use updated links below if there is a new release.
+Make sure to use updated links below if there is a new release. The latest release is [here](https://github.com/eikek/docspell/releases/latest).
+
+Docspell consists of two components, the restserver and the joex (job executor). Both are configured separately, but also share some configuration values (e.g. the database and full-text search). The restserver is providing the user interface and allows to query all data. The joex is running all the long running tasks in the background.
 
 ```
 cd /tmp
@@ -112,6 +126,7 @@ wget https://github.com/eikek/docspell/releases/download/v0.32.0/docspell-joex_0
 wget https://github.com/eikek/docspell/releases/download/v0.32.0/docspell-restserver_0.32.0_all.deb
 dpki -i docspell*
 ```
+
 At this point, doscpell itself is installed, but we'll also need the commandline tool dsc:
 ```
 wget https://github.com/docspell/dsc/releases/download/v0.7.0/dsc_amd64-musl-0.7.0
@@ -119,7 +134,8 @@ mv dsc_amd* dsc
 chmod +x dsc
 mv dsc /usr/bin
 ```
-Now dsc is available from the command line.
+The latest release of dsc can be found [here](https://github.com/docspell/dsc/releases/latest). Now dsc is available from the command line.
+
 
 ## Docspell configuration
 
@@ -127,27 +143,39 @@ You'll find links to the configuration files for docspell-restserver (which incl
 
 You can use the files linked here, but don't forget to update the passwords in them.
 
-Link to docspell-restserver example
-Link to docsspell-joex example
+*Note: You need to enable full-text search in both config files, as it is disabled by default. Also the database connection should be configured. The default values can be seen [here](https://docspell.org/docs/configure/main/#default-config).*
+
 
 After editing the configuration files to your needs, it's time to start the docspell services:
 
 ```
-systemctl start docspell-resterver
+systemctl start docspell-restserver
 systemctl enable docspell-restserver
 systemctl start docspell-joex
 systemctl enable docspell-joex
 ```
 
-## Enable SOLR fulltext search
+You should be able to reach the web interface at <http://localhost:7880>.
 
-We need to create a SOLR core and make it available in Docspell:
+When you create a new account, use the exact same name for "collective" and "username". For more information on this, please see [here](https://docspell.org/docs/#collective).
+
+The logs can be inspected via `journalctl`, for example:
+```
+journalctl -efu docspell-restserver  #or
+journalctl -efu docspell-joex
+```
+
+## Recreate fulltext index
+
+In some situations it can be necessary to re-create the fulltext index, for example if you enable full-text search after running docspel without. It is therefore not necessary on new installations. 
+
+The following command is requesting docspell to re-index all data. The `dsc` tool that has been installed above is used for this:
 
 ```
-su solr -c '/opt/solr-8.11.1/bin/solr create -c docspell'
-curl -XPOST -H "Docspell-Admin-Secret: my secret" http://localhost:7880/api/v1/admin/fts/reIndexAll
-
+dsc -d http://localhost:7880 admin -a 'my admin secret' recreate-index
 ```
+
+The admin secret must be set in the [configuration file](https://docspell.org/docs/configure/admin-endpoint/) (which requires a restart). 
 
 ## Nginx Reverse Proxy
 ```


### PR DESCRIPTION
Hi @andreklug , here are only some minor things. Mostly added explanations I thought could be useful if you start new.

- For inline verbatim text, use one backtick and use three backticks
  on separate lines
- I think we should make people configure SOLR (the core) first and
  then docspell, so a re-index is not necessary.
- Added some explanations
- Use dsc for re-creating the index